### PR TITLE
Add "modules" rule

### DIFF
--- a/features/modules.feature
+++ b/features/modules.feature
@@ -1,0 +1,192 @@
+Feature: modules
+
+Background:
+  Given the "modules" rule is enabled with
+    """
+    [2, [
+      {
+        "externals": ["postgres", "redis"],
+        "interface": ["/readers/.*/types$", "/readers/\\w+$"],
+        "message": "Data module is defined in https://path/to/docs",
+        "path": "src/data"
+      },
+      {
+        "dependencies": ["src/data"],
+        "interface": ["/controllers/\\w+"],
+        "path": "src/business"
+      },
+      {
+        "dependencies": ["src/business"],
+        "externals": ["async-app", "mural-schema"],
+        "message": "Check transport module in eslintc.js",
+        "path": "src/transport"
+      }
+    ]]
+    """
+
+# Intra-module
+
+Scenario: allow private intra-module dependencies
+  When linting "./src/data/private/file.js" with
+    """
+    import '../common/other';
+    """
+  Then the code is OK
+
+Scenario: allow module interface importing module implementation
+  When linting "./src/data/readers/file.js" with
+    """
+    import '../private/other';
+    """
+  Then the code is OK
+
+Scenario: allow module implementation importing module interface
+  When linting "./src/data/private/file.js" with
+    """
+    import '../readers/other';
+    """
+  Then the code is OK
+
+# Non-module
+
+Scenario: allow non-module dependencies
+  When linting "./src/non-module/file.js" with
+    """
+    import './other';
+    """
+  Then the code is OK
+
+Scenario: allow non-module to import module interface
+  When linting "./src/app.js" with
+    """
+    import './data/readers/other';
+    """
+  Then the code is OK
+
+Scenario: reject non-module importing module implementation
+  When linting "./src/app.js" with
+    """
+    import './data/private/other';
+    """
+  Then an error is at
+    """
+    >>>import './data/private/other';<<<
+    """
+  And that error message includes
+    """
+    Module abstraction violation: './src/app.js' cannot import './data/private/other'.
+    
+    './data/private/other' is part of module 'src/data' but not listed in the module public
+    interface (i.e. is an implementation detail).
+
+    Data module is defined in https://path/to/docs
+    """
+
+# Module externals
+
+Scenario: allow explicit externals
+  When linting "./src/data/private/file.js" with
+    """
+    import 'postgres';
+    """
+  Then the code is OK
+
+Scenario: allow implicit externals (no module limitation)
+  When linting "./src/business/private/file.js" with
+    """
+    import 'ms';
+    """
+  Then the code is OK
+
+Scenario: reject invalid externals
+  When linting "./src/transport/file.js" with
+    """
+    import 'redis';
+    """
+  Then an error is at
+    """
+    >>>import 'redis';<<<
+    """
+  And that error message includes
+    """
+    Module abstraction violation: './src/transport/file.js' cannot import 'redis'.
+    
+    'src/transport' has an explicit list of allowed external imports and 'redis' is not
+    in this list.
+
+    Check transport module in eslintc.js
+    """
+
+# Cross-module
+
+Scenario: allow explicit cross-module import
+  When linting "./src/business/private/file.js" with
+    """
+    import '../../data/readers/other';
+    """
+  Then the code is OK
+
+Scenario: reject target module not listed in this module's dependencies
+  When linting "./src/data/file.js" with
+    """
+    import '../business/controllers/other';
+    """
+  Then an error is at
+    """
+    >>>import '../business/controllers/other';<<<
+    """
+  And that error message includes
+    """
+    Module abstraction violation: './src/data/file.js' cannot import '../business/controllers/other'.
+    
+    'src/business' is not listed as a valid dependency of 'src/data'.
+
+    Data module is defined in https://path/to/docs
+    """
+
+# NodeJS require support
+
+Scenario: allow explicit cross-module import (node)
+  When linting "./src/business/private/file.js" with
+    """
+    require('../../data/readers/other');
+    """
+  Then the code is OK
+
+Scenario: reject target module not listed in this module's dependencies
+  When linting "./src/data/file.js" with
+    """
+    require('../business/controllers/other');
+    """
+  Then an error is at
+    """
+    >>>require('../business/controllers/other')<<<
+    """
+  And that error message includes
+    """
+    Module abstraction violation: './src/data/file.js' cannot import '../business/controllers/other'.
+    
+    'src/business' is not listed as a valid dependency of 'src/data'.
+
+    Data module is defined in https://path/to/docs
+    """
+
+# Path matching
+
+Scenario: no false positives with path prefix for module spec
+  # `src/data` is a module, but `src/data-stuff` is not part of that module!
+  When linting "./src/data-stuff.js" with
+    """
+    import 'random-external';
+    """
+  Then the code is OK
+
+Scenario: no false positives with path prefix for import
+  # `src/data` is a module, but `src/data-stuff` is not part of that module!
+  When linting "./src/business/file.js" with
+    """
+    import '../data-stuff';
+    """
+  Then the code is OK
+  # because we can import random code from `src/business` and `data-stuff` is
+  # being picked up as a private implementation of `src/data`

--- a/package-lock.json
+++ b/package-lock.json
@@ -812,9 +812,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -1002,9 +1002,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.unescape": {
@@ -1106,9 +1106,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "object-assign": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-muralco",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-muralco",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Standard rules for MURAL",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import layersRule from './layers';
+import modulesRule from './modules';
 import sortedImportsRule from './sorted-imports';
 import customJsxRule from './custom-jsx';
 
@@ -14,6 +15,7 @@ module.exports = {
   rules: {
     'custom-jsx': customJsxRule,
     layers: layersRule,
+    modules: modulesRule,
     'sorted-imports': sortedImportsRule,
   },
 };

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,0 +1,137 @@
+import { Rule } from 'eslint';
+import { sep } from 'path';
+import { defineImportRule, toRe } from './util';
+
+interface ModuleOption {
+  dependencies?: string[];
+  externals?: string[];
+  interface?: string[] | string;
+  message?: string;
+  path: string;
+}
+
+interface ModuleSpec {
+  dependencies: string[];
+  externals: RegExp[];
+  interfaces: RegExp[];
+  message: string | undefined;
+  path: string;
+}
+
+const ALLOW_ALL: RegExp[] = [];
+
+const PRIVATE_IMPLEMENTATION = `Module abstraction violation: '{from}' cannot import '{to}'.
+
+'{to}' is part of module '{toModule}' but not listed in the module public
+interface (i.e. is an implementation detail).`;
+
+const NOT_A_DEPENDENCY = `Module abstraction violation: '{from}' cannot import '{to}'.
+
+'{toModule}' is not listed as a valid dependency of '{fromModule}'.`;
+
+const INVALID_EXTERNAL = `Module abstraction violation: '{from}' cannot import '{to}'.
+
+'{fromModule}' has an explicit list of allowed external imports and '{to}' is not
+in this list.`;
+
+const matchPath = (specPath: string, otherPath: string): boolean =>
+  otherPath === specPath || otherPath.includes(`${specPath}${sep}`);
+
+const modulesRule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      description: 'enforce module abstraction',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    schema: [
+      {
+        items: {
+          properties: {
+            dependencies: { type: 'array', items: { type: 'string' } },
+            interface: {
+              oneOf: [
+                { type: 'array', items: { type: 'string' } },
+                { type: 'string' },
+              ],
+            },
+            message: { type: 'string' },
+            path: { type: 'string', required: true },
+          },
+          type: 'object',
+        },
+        required: true,
+        type: 'array',
+      },
+    ],
+    type: 'suggestion',
+  },
+  create: defineImportRule<ModuleOption, ModuleSpec>({
+    applySpecs: (specs, from, getTo) => {
+      const fromModule = specs.find(s =>
+        matchPath(s.path, from.absoluteFilePath),
+      );
+      const to = getTo();
+      const toModule = specs.find(s =>
+        matchPath(s.path, to.absoluteImportedPath),
+      );
+      // Always allow inter-module imports
+      if (fromModule === toModule) return [];
+
+      // The `import` clause targets a known module
+      if (toModule) {
+        // The `import` is not targeting the module's public interface
+        if (!toModule.interfaces.some(i => to.absoluteImportedPath.match(i))) {
+          return [
+            `${PRIVATE_IMPLEMENTATION.replace(/\{toModule\}/g, toModule.path)}${
+              toModule.message ? `\n\n${toModule.message}` : ''
+            }`,
+          ];
+        }
+        if (fromModule && !fromModule.dependencies.includes(toModule.path)) {
+          return [
+            `${NOT_A_DEPENDENCY.replace(/\{toModule\}/g, toModule.path).replace(
+              /\{fromModule\}/g,
+              fromModule.path,
+            )}${fromModule.message ? `\n\n${fromModule.message}` : ''}`,
+          ];
+        }
+        // We are importing some other module's public interface and our module
+        // (if any), lists the imported module as an explicit dependency, so
+        // we're good
+        return [];
+      }
+
+      // We are in a module but we are importing an external file (not part of
+      // any module)
+      if (
+        fromModule &&
+        fromModule.externals !== ALLOW_ALL &&
+        !fromModule.externals.some(e => to.absoluteImportedPath.match(e))
+      ) {
+        return [
+          `${INVALID_EXTERNAL.replace(/\{fromModule\}/g, fromModule.path)}${
+            fromModule.message ? `\n\n${fromModule.message}` : ''
+          }`,
+        ];
+      }
+
+      return [];
+    },
+    resolveOptions: opts =>
+      opts.map(opt => ({
+        dependencies: opt.dependencies || [],
+        externals: opt.externals ? opt.externals.map(toRe) : ALLOW_ALL,
+        interfaces: (Array.isArray(opt.interface)
+          ? opt.interface
+          : opt.interface
+          ? [opt.interface]
+          : []
+        ).map(toRe),
+        message: opt.message,
+        path: opt.path,
+      })),
+  }),
+};
+
+export default modulesRule;

--- a/src/test.ts
+++ b/src/test.ts
@@ -131,6 +131,25 @@ const setup: SetupFn = ({
           message,
         }),
       );
+      setCtx(
+        '$line-error',
+        result.messages
+          .filter(
+            m =>
+              m.column === start.column &&
+              m.line === start.line &&
+              m.endColumn === end.column &&
+              m.endLine === end.line,
+          )
+          .map(m => m.message),
+      );
+    },
+    { inline: true },
+  );
+  Then(
+    'that error message includes',
+    message => {
+      compare('includes', getCtx('$line-error'), JSON.stringify(message));
     },
     { inline: true },
   );

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,111 @@
+import { Rule } from 'eslint';
+import { Identifier, Node } from 'estree';
+import { dirname, resolve } from 'path';
+
+export const toRe = (s: string): RegExp => new RegExp(s);
+
+const isNotNull = <T>(x: T | null): x is T => x !== null;
+
+interface FromInfo {
+  filePath: string;
+  absoluteFilePath: string;
+  absoluteFileDir: string;
+}
+
+interface ImportInfo {
+  importPath: string;
+  absoluteImportedPath: string;
+  absoluteImportedDir: string;
+}
+
+export interface ImportRule<TOption, TSpec> {
+  applySpecs: (
+    specs: TSpec[],
+    from: FromInfo,
+    to: () => ImportInfo,
+  ) => (string | null)[]; // returns the array of (generic) error messages
+  resolveOptions: (opts: TOption[]) => TSpec[];
+}
+
+export const defineImportRule = <TOption, TSpec>({
+  applySpecs,
+  resolveOptions,
+}: ImportRule<TOption, TSpec>): Rule.RuleModule['create'] => {
+  let cachedOpts: TOption[] | undefined;
+  let cachedSpecs: TSpec[] | undefined;
+
+  const cachedResolveOptions = (opts: TOption[]): TSpec[] => {
+    if (opts === cachedOpts && cachedSpecs) return cachedSpecs;
+    cachedSpecs = resolveOptions(opts);
+    return cachedSpecs;
+  };
+
+  return (context: Rule.RuleContext): Rule.RuleListener => {
+    const filePath = context.getFilename();
+    const absoluteFilePath = resolve(filePath);
+    const absoluteFileDir = dirname(absoluteFilePath);
+    const specs = cachedResolveOptions(context.options[0] as TOption[]);
+
+    const fromInfo: FromInfo = {
+      absoluteFileDir,
+      absoluteFilePath,
+      filePath,
+    };
+
+    const applyRule = (node: Node, importedPath: string): void => {
+      const importInfo: ImportInfo = {
+        importPath: importedPath,
+        absoluteImportedDir: '',
+        absoluteImportedPath: '',
+      };
+
+      const getImportInfo = (): ImportInfo => {
+        if (importInfo.absoluteImportedPath) return importInfo;
+        importInfo.absoluteImportedPath =
+          importInfo.importPath[0] === '.'
+            ? resolve(absoluteFileDir, importedPath)
+            : importedPath;
+        importInfo.absoluteImportedDir = dirname(
+          importInfo.absoluteImportedPath,
+        );
+
+        return importInfo;
+      };
+
+      const failing = applySpecs(specs, fromInfo, getImportInfo).filter(
+        isNotNull,
+      );
+
+      if (!failing.length) return;
+
+      const reported: string[] = [];
+      failing.forEach(message => {
+        if (reported.includes(message)) return;
+        reported.push(message);
+        context.report({
+          message: message
+            .replace(/\{from\}/g, filePath)
+            .replace(/\{to\}/g, importedPath),
+          node,
+        });
+      });
+    };
+
+    return {
+      ImportDeclaration: function(node): void {
+        if (node.type === 'ImportDeclaration') {
+          applyRule(node, node.source.value as string);
+        }
+      },
+      CallExpression: function(node): void {
+        if (
+          node.type === 'CallExpression' &&
+          (node.callee as Identifier).name === 'require' &&
+          node.arguments[0].type === 'Literal'
+        ) {
+          applyRule(node, node.arguments[0].value as string);
+        }
+      },
+    };
+  };
+};


### PR DESCRIPTION
`modules` is a lighter, more opinionated version of `layers`.

Rules:
- A "module" has a root directory (i.e. `path`), and a public `interface`.
- Any file inside the module can import any other file.
- Files _outside_ the module can only import files in the module's `interface`
- A module can have an optional `dependencies` list. If present for module `M`, this list includes other modules that `M` can import (the rule above still applies, `M` can only import the public interface of these other modules).
- A module can have an optional `externals` list. This list can be used to constrain the NPM packages that can be imported by any file within the module's path to just items in this list.