### PR TITLE
Fix export from not being picked up by modules/layers

### DIFF
--- a/features/modules/index.feature
+++ b/features/modules/index.feature
@@ -40,10 +40,24 @@ Scenario: allow module interface importing module implementation
     """
   Then the code is OK
 
+Scenario: allow re-exporting implementation
+  When linting "./src/data/readers/file.js" with
+    """
+    export { fn } from '../private/other';
+    """
+  Then the code is OK
+
 Scenario: allow module implementation importing module interface
   When linting "./src/data/private/file.js" with
     """
     import '../readers/other';
+    """
+  Then the code is OK
+
+Scenario: allow re-exporting interface
+  When linting "./src/data/readers/file.js" with
+    """
+    export { fn } from '../readers/other';
     """
   Then the code is OK
 
@@ -56,10 +70,24 @@ Scenario: allow non-module dependencies
     """
   Then the code is OK
 
+Scenario: allow re-export non-module dependencies
+  When linting "./src/non-module/file.js" with
+    """
+    export { fn } from './other';
+    """
+  Then the code is OK
+
 Scenario: allow non-module to import module interface
   When linting "./src/app.js" with
     """
     import './data/readers/other';
+    """
+  Then the code is OK
+
+Scenario: allow non-module to re-export module interface
+  When linting "./src/app.js" with
+    """
+    export { fn } from './data/readers/other';
     """
   Then the code is OK
 
@@ -71,6 +99,63 @@ Scenario: reject non-module importing module implementation
   Then an error is at
     """
     >>>import './data/private/other';<<<
+    """
+  And that error message includes
+    """
+    Module abstraction violation: './src/app.js' cannot import './data/private/other'.
+    
+    './data/private/other' is part of module 'src/data' but not listed in the module public
+    interface (i.e. is an implementation detail).
+
+    Data module is defined in https://path/to/docs
+    """
+
+Scenario: reject non-module re-exporting module implementation
+  When linting "./src/app.js" with
+    """
+    export { fn } from './data/private/other';
+    """
+  Then an error is at
+    """
+    >>>export { fn } from './data/private/other';<<<
+    """
+  And that error message includes
+    """
+    Module abstraction violation: './src/app.js' cannot import './data/private/other'.
+    
+    './data/private/other' is part of module 'src/data' but not listed in the module public
+    interface (i.e. is an implementation detail).
+
+    Data module is defined in https://path/to/docs
+    """
+
+Scenario: reject non-module re-exporting full module implementation
+  When linting "./src/app.js" with
+    """
+    export * from './data/private/other';
+    """
+  Then an error is at
+    """
+    >>>export * from './data/private/other';<<<
+    """
+  And that error message includes
+    """
+    Module abstraction violation: './src/app.js' cannot import './data/private/other'.
+    
+    './data/private/other' is part of module 'src/data' but not listed in the module public
+    interface (i.e. is an implementation detail).
+
+    Data module is defined in https://path/to/docs
+    """
+
+Scenario: reject non-module re-exporting default module implementation
+  When linting "./src/app.js" with
+    """
+    export { default as fn } from './data/private/other';
+    """
+  Then an error is at
+    """
+    >>>export { default as fn } from './data/private/other';<<<
     """
   And that error message includes
     """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-muralco",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-muralco",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Standard rules for MURAL",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import { Rule } from 'eslint';
-import { CallExpression, Identifier, ImportDeclaration } from 'estree';
+import { CallExpression, Identifier, ModuleDeclaration } from 'estree';
 import { dirname, resolve } from 'path';
 
 export const toRe = (s: string): RegExp => new RegExp(s);
@@ -12,7 +12,7 @@ export interface FromInfo {
   absoluteFileDir: string;
 }
 
-type ImportNode = ImportDeclaration | CallExpression;
+type ImportNode = ModuleDeclaration | CallExpression;
 
 export interface ImportInfo {
   importPath: string;
@@ -95,6 +95,16 @@ export const defineImportRule = ({
     };
 
     return {
+      ExportAllDeclaration: function(node): void {
+        if (node.type === 'ExportAllDeclaration') {
+          applyRuleInternal(node, node.source.value as string);
+        }
+      },
+      ExportNamedDeclaration: function(node): void {
+        if (node.type === 'ExportNamedDeclaration' && node.source) {
+          applyRuleInternal(node, node.source.value as string);
+        }
+      },
       ImportDeclaration: function(node): void {
         if (node.type === 'ImportDeclaration') {
           applyRuleInternal(node, node.source.value as string);


### PR DESCRIPTION
Fix `export { fn } from '../somewhere'` not being picked up by modules/layers rules