### PR TITLE
Add support for narrow module dependencies

### DIFF
--- a/features/modules/narrow-dependencies.feature
+++ b/features/modules/narrow-dependencies.feature
@@ -1,0 +1,59 @@
+Feature: modules (narrow dependencies)
+
+Background:
+  Given the "modules" rule is enabled with
+    """
+    [2, [
+      {
+        "path": "src/a",
+        "dependencies": [{ "path": "src/b", "on": ["/only/"] }]
+      },
+      { "path": "src/b", "interface": ".*" },
+      { "path": "src/c", "interface": ".*" }
+    ]]
+    """
+
+Scenario: allow import on the listed interface
+  When linting "./src/a/file.ts" with
+    """
+    import '../b/only/file';
+    """
+  Then the code is OK
+
+Scenario: reject import on unlisted modules
+  When linting "./src/a/file.ts" with
+    """
+    import '../c/only/file';
+    """
+  Then an error is at
+    """
+    >>>import '../c/only/file';<<<
+    """
+  And that error message matches MODULE_OUTBOUND_DEPENDENCY with
+    """
+    {
+      "from": "./src/a/file.ts",
+      "to": "../c/only/file",
+      "fromModule": "src/a",
+      "toModule": "src/c"
+    }
+    """
+
+Scenario: reject import on unscoped interface of listed module
+  When linting "./src/a/file.ts" with
+    """
+    import '../b/other/file';
+    """
+  Then an error is at
+    """
+    >>>import '../b/other/file';<<<
+    """
+  And that error message matches MODULE_OUTBOUND_DEPENDENCY with
+    """
+    {
+      "from": "./src/a/file.ts",
+      "to": "../b/other/file",
+      "fromModule": "src/a",
+      "toModule": "src/b"
+    }
+    """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-muralco",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-muralco",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Standard rules for MURAL",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Allow module dependencies to be expressed as a string or as a `{ path: string; on: string[] }` where the `on` part specifies path patterns that the module import must match.

This effectively allows you to say "module `A` depends on module `B` but only on `b/some-stuff` and not on `b/other-stuff`"